### PR TITLE
Enforce single start event constraint in JSON generator

### DIFF
--- a/src/bpmn_assistant/services/bpmn_json_generator.py
+++ b/src/bpmn_assistant/services/bpmn_json_generator.py
@@ -33,6 +33,13 @@ class BpmnJsonGenerator:
         root = ET.fromstring(bpmn_xml)
         process_element = self._find_process_element(root)
         self._get_elements_and_flows(process_element)
+        start_events = [
+            elem
+            for elem in self.elements.values()
+            if elem["type"] == BPMNElementType.START_EVENT.value
+        ]
+        if len(start_events) != 1:
+            raise ValueError("Process must contain exactly one start event")
         self._build_process_structure()
         return self.process
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -590,3 +590,9 @@ def labeled_events_process():
 def bpmn_xml_labeled_events():
     """Description: BPMN XML with labeled start and end events."""
     return load_bpmn("labeled_events.bpmn")
+
+@pytest.fixture
+def bpmn_xml_two_start_events():
+    """BPMN XML with two start events."""
+    return load_bpmn("two_start_events.bpmn")
+

--- a/tests/fixtures/two_start_events.bpmn
+++ b/tests/fixtures/two_start_events.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_two_starts" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
+  <bpmn:process id="Process_two_starts" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_2">
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Task A">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Task_2" name="Task B">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="StartEvent_2" targetRef="Task_2" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="Task_2" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>
+

--- a/tests/services/test_bpmn_json_generator.py
+++ b/tests/services/test_bpmn_json_generator.py
@@ -1,3 +1,4 @@
+import pytest
 from bpmn_assistant.services import BpmnJsonGenerator
 
 
@@ -748,3 +749,9 @@ class TestBpmnJsonGenerator:
         ]
 
         assert result == expected
+
+    def test_create_bpmn_json_multiple_start_events(self, bpmn_xml_two_start_events):
+        bpmn_json_generator = BpmnJsonGenerator()
+        with pytest.raises(ValueError, match="Process must contain exactly one start event"):
+            bpmn_json_generator.create_bpmn_json(bpmn_xml_two_start_events)
+


### PR DESCRIPTION
## Summary
- validate exactly one start event in `BpmnJsonGenerator.create_bpmn_json`
- add BPMN fixture for multiple start events
- expose new fixture in tests
- add unit test expecting ValueError when BPMN contains more than one start event

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683f4daabacc83328e955ec64264e5ea