### PR TITLE
Add image handling to LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Note: You can use any combination of the API keys above, but at least one is req
 3. Diagram interpretation - Provides text descriptions of BPMN diagrams.
 4. Drag-and-drop functionality - Users can drag and drop BPMN files (containing only supported elements) into the
    editor, then ask the LLM to edit or explain the process.
+5. Image attachments - Paste, drag, or upload an image to include it with a chat message.
 
 ## Supported elements
 

--- a/src/bpmn_assistant/core/llm_provider.py
+++ b/src/bpmn_assistant/core/llm_provider.py
@@ -9,7 +9,7 @@ class LLMProvider(ABC):
     def call(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
         structured_output: BaseModel | None = None,
@@ -20,14 +20,14 @@ class LLMProvider(ABC):
     def stream(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
     ) -> Generator[str, None, None]:
         pass
 
     @abstractmethod
-    def get_initial_messages(self) -> list[dict[str, str]]:
+    def get_initial_messages(self) -> list[dict[str, Any]]:
         pass
 
     @abstractmethod

--- a/src/bpmn_assistant/core/provider_impl/anthropic_provider.py
+++ b/src/bpmn_assistant/core/provider_impl/anthropic_provider.py
@@ -15,10 +15,25 @@ class AnthropicProvider(LLMProvider):
         self.output_mode = output_mode
         self.client = Anthropic(api_key=api_key)
 
+    def _format_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted: list[dict[str, Any]] = []
+        for message in messages:
+            if message.get("image_url"):
+                parts = []
+                parts.append(
+                    {"type": "image", "source": {"type": "url", "url": message["image_url"]}}
+                )
+                if message.get("content"):
+                    parts.append({"type": "text", "text": message["content"]})
+                formatted.append({"role": message["role"], "content": parts})
+            else:
+                formatted.append({"role": message["role"], "content": message.get("content", "")})
+        return formatted
+
     def call(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
         structured_output: BaseModel | None = None,
@@ -35,7 +50,7 @@ class AnthropicProvider(LLMProvider):
                 max_tokens=max_tokens,
                 temperature=temperature,
                 system="You are a helpful assistant designed to output JSON.",
-                messages=messages,  # type: ignore[arg-type]
+                messages=self._format_messages(messages),  # type: ignore[arg-type]
             )
 
             content = response.content[0]
@@ -57,7 +72,7 @@ class AnthropicProvider(LLMProvider):
                 model=model,
                 max_tokens=max_tokens,
                 temperature=temperature,
-                messages=messages,  # type: ignore[arg-type]
+                messages=self._format_messages(messages),  # type: ignore[arg-type]
             )
 
             content = response.content[0]
@@ -72,7 +87,7 @@ class AnthropicProvider(LLMProvider):
     def stream(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
     ) -> Generator[str, None, None]:
@@ -83,14 +98,14 @@ class AnthropicProvider(LLMProvider):
             model=model,
             max_tokens=max_tokens,
             temperature=temperature,
-            messages=messages,  # type: ignore[arg-type]
+            messages=self._format_messages(messages),  # type: ignore[arg-type]
         )
 
         with response as stream:
             for text in stream.text_stream:
                 yield text
 
-    def get_initial_messages(self) -> list[dict[str, str]]:
+    def get_initial_messages(self) -> list[dict[str, Any]]:
         return []
 
     def check_model_compatibility(self, model: str) -> bool:

--- a/src/bpmn_assistant/core/provider_impl/litellm_provider.py
+++ b/src/bpmn_assistant/core/provider_impl/litellm_provider.py
@@ -1,13 +1,13 @@
 import json
 import os
 import re
+import mimetypes
 from typing import Any, Generator
 
 from litellm import completion
 from pydantic import BaseModel
 
 from bpmn_assistant.config import logger
-from bpmn_assistant.core.enums.message_roles import MessageRole
 from bpmn_assistant.core.enums.models import (
     FireworksAIModels,
     GoogleModels,
@@ -24,17 +24,39 @@ class LiteLLMProvider(LLMProvider):
         os.environ["OPENAI_API_KEY"] = api_key
         os.environ["GEMINI_API_KEY"] = api_key
 
+    def _format_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted: list[dict[str, Any]] = []
+        for message in messages:
+            if message.get("image_url"):
+                mime, _ = mimetypes.guess_type(message["image_url"])
+                parts = []
+                if message.get("content"):
+                    parts.append({"type": "text", "text": message["content"]})
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": message["image_url"],
+                            **({"format": mime} if mime else {}),
+                        },
+                    }
+                )
+                formatted.append({"role": message["role"], "content": parts})
+            else:
+                formatted.append({"role": message["role"], "content": message.get("content", "")})
+        return formatted
+
     def call(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
         structured_output: BaseModel | None = None,
     ) -> str | dict[str, Any]:
         params: dict[str, Any] = {
             "model": model,
-            "messages": messages,
+            "messages": self._format_messages(messages),
         }
 
         if structured_output is not None or self.output_mode == OutputMode.JSON:
@@ -72,13 +94,13 @@ class LiteLLMProvider(LLMProvider):
     def stream(
         self,
         model: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         max_tokens: int,
         temperature: float,
     ) -> Generator[str, None, None]:
         response = completion(
             model=model,
-            messages=messages,
+            messages=self._format_messages(messages),
             max_tokens=max_tokens,
             temperature=temperature,
             stream=True,
@@ -129,7 +151,7 @@ class LiteLLMProvider(LLMProvider):
             if thought:
                 logger.info(f"Model thinking phase: {thought}")
 
-    def get_initial_messages(self) -> list[dict[str, str]]:
+    def get_initial_messages(self) -> list[dict[str, Any]]:
         return (
             [
                 {

--- a/src/bpmn_assistant/core/schemas.py
+++ b/src/bpmn_assistant/core/schemas.py
@@ -13,6 +13,7 @@ class MessageItem(BaseModel):
 
     role: str
     content: str
+    image_url: Optional[str] = None
 
 
 class BPMNTask(BaseModel):

--- a/src/bpmn_assistant/utils/utils.py
+++ b/src/bpmn_assistant/utils/utils.py
@@ -106,6 +106,11 @@ def message_history_to_string(message_history: list[MessageItem]) -> str:
     """
     Convert a message history list into a formatted string.
     """
-    return "\n".join(
-        f"{message.role.capitalize()}: {message.content}" for message in message_history
-    )
+    formatted_messages = []
+    for message in message_history:
+        text = message.content
+        if message.image_url:
+            text = (text + " [Image attached]") if text else "[Image attached]"
+        formatted_messages.append(f"{message.role.capitalize()}: {text}")
+
+    return "\n".join(formatted_messages)

--- a/src/bpmn_frontend/src/components/ChatInterface.vue
+++ b/src/bpmn_frontend/src/components/ChatInterface.vue
@@ -59,6 +59,7 @@
           :key="index"
           :role="message.role"
           :content="message.content"
+          :image-url="message.image_url"
         />
 
         <LoadingIndicator v-if="isLoading" />
@@ -96,6 +97,9 @@
           :counter="10000"
           rows="4"
           @keydown.enter.prevent="handleKeyDown"
+          @paste="handlePaste"
+          @dragover.prevent
+          @drop.prevent="handleDrop"
           hide-details
           class="input-textarea"
           density="comfortable"
@@ -103,9 +107,24 @@
           bg-color="white"
         >
         </v-textarea>
+        <input
+          type="file"
+          accept="image/*"
+          ref="imageInput"
+          @change="handleImageChange"
+          style="display: none"
+        />
+        <img v-if="selectedImage" :src="selectedImage" class="preview-image" />
+        <v-btn
+          icon="mdi-image"
+          variant="text"
+          size="small"
+          :disabled="isLoading"
+          @click="triggerImageSelect"
+        ></v-btn>
         <v-btn
           @click="handleMessageSubmit"
-          :disabled="isLoading || !currentInput.trim()"
+          :disabled="isLoading || (!currentInput.trim() && !selectedImage)"
           color="primary"
           class="send-button"
           icon="mdi-send"
@@ -149,6 +168,7 @@ export default {
       messages: [],
       currentInput: '',
       selectedModel: '',
+      selectedImage: null,
       hasError: false,
     };
   },
@@ -184,8 +204,48 @@ export default {
         this.handleMessageSubmit();
       }
     },
+    triggerImageSelect() {
+      this.$refs.imageInput.click();
+    },
+    handlePaste(event) {
+      const items = event.clipboardData?.items || [];
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+              this.selectedImage = e.target.result;
+            };
+            reader.readAsDataURL(file);
+          }
+        }
+      }
+    },
+    handleDrop(event) {
+      const file = event.dataTransfer.files[0];
+      if (!file || !file.type.startsWith('image/')) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        this.selectedImage = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    },
+    handleImageChange(event) {
+      const file = event.target.files[0];
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        this.selectedImage = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    },
     async handleMessageSubmit() {
-      if (!this.currentInput.trim()) {
+      if (!this.currentInput.trim() && !this.selectedImage) {
         return;
       }
 
@@ -202,8 +262,9 @@ export default {
       // Clear any previous errors
       this.hasError = false;
 
-      this.messages.push({ content: this.currentInput, role: 'user' });
+      this.messages.push({ content: this.currentInput, role: 'user', image_url: this.selectedImage });
       this.currentInput = '';
+      this.selectedImage = null;
 
       this.$nextTick(() => {
         this.scrollToBottom();
@@ -416,6 +477,13 @@ export default {
 
 .input-textarea {
   flex-grow: 1;
+}
+
+.preview-image {
+  max-width: 80px;
+  max-height: 80px;
+  margin-right: 8px;
+  border-radius: 4px;
 }
 
 .app-title {

--- a/src/bpmn_frontend/src/components/MessageCard.vue
+++ b/src/bpmn_frontend/src/components/MessageCard.vue
@@ -6,6 +6,7 @@
           <b>{{ roleDisplay }}</b>
         </div>
         <div class="message-content" v-html="formattedContent"></div>
+        <img v-if="imageUrl" :src="imageUrl" class="message-image" />
       </div>
     </div>
   </transition>
@@ -16,6 +17,7 @@ export default {
   props: {
     role: String,
     content: String,
+    imageUrl: String,
   },
   computed: {
     roleDisplay() {
@@ -105,6 +107,12 @@ export default {
 .message-content {
   font-size: 1em;
   line-height: 1.4;
+}
+
+.message-image {
+  margin-top: 8px;
+  max-width: 100%;
+  border-radius: 4px;
 }
 
 .message-content ::v-deep(strong) {


### PR DESCRIPTION
## Summary
- allow provider messages to include `image_url`
- format images for LiteLLM using `image_url` blocks
- format images for Anthropic using image sources

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68409606e380833299e4090bd44b19d4